### PR TITLE
Added images folder and content to files section in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
     "version": "1.10.10",
     "description": "DataTables for jQuery ",
     "files": [
-        "css/jquery.dataTables.css"
+        "css/jquery.dataTables.css",
+        "images/sort_asc.png",
+        "images/sort_asc_disabled.png",
+        "images/sort_both.png",
+        "images/sort_desc.png",
+        "images/sort_desc_disabled.png"
     ],
     "keywords": [
         "filter",


### PR DESCRIPTION
I'm working with Webpack, and it's awesome.

In my recently project I decided to include DataTables via NPM, but when webpack is loading the `datatables.net-dt/css/jquery.dataTables.css` file I was having trouble finding the referenced images and I noticed that the current release did not include them.
